### PR TITLE
chore(update): is-glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/es128/glob-parent",
   "dependencies": {
-    "is-glob": "^3.1.0",
+    "is-glob": "^4.0.0",
     "path-dirname": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
/cc @es128 @phated i need some feedback on this update (tests failed) due `?` character. 

What we can do:
1. Modify https://github.com/es128/glob-parent/blob/master/index.js#L20 regexp for backward compatobility
2. Release major version and remove https://github.com/es128/glob-parent/blob/master/test.js#L50 and https://github.com/es128/glob-parent/blob/master/test.js#L55 tests

`?` is valid character for `windows`