### PR TITLE
ISSUE-24: Ability to avoid autoreplace \\ in patterns even on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,18 @@ globParent('path/foo'); // 'path' (see issue #3 for details)
 
 ## API
 
-### `globParent(maybeGlobString)`
+### `globParent(maybeGlobString, [options])`
 
 Takes a string and returns the part of the path before the glob begins. Be aware of Escaping rules and Limitations below.
+
+#### options
+
+```js
+{
+  // Disables the automatic conversion of slashes for Windows
+  flipBackslashes: true
+}
+```
 
 ## Escaping
 

--- a/index.js
+++ b/index.js
@@ -10,9 +10,16 @@ var enclosure = /[\{\[].*[\/]*.*[\}\]]$/;
 var globby = /(^|[^\\])([\{\[]|\([^\)]+$)/;
 var escaped = /\\([\*\?\|\[\]\(\)\{\}])/g;
 
-module.exports = function globParent(str) {
+/**
+ * @param {string} str
+ * @param {Object} opts
+ * @param {boolean} [opts.flipBackslashes=true]
+ */
+module.exports = function globParent(str, opts) {
+  var options = Object.assign({ flipBackslashes: true }, opts);
+
   // flip windows path separators
-  if (isWin32 && str.indexOf(slash) < 0) {
+  if (options.flipBackslashes && isWin32 && str.indexOf(slash) < 0) {
     str = str.replace(backslash, slash);
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,7 +84,12 @@ describe('glob-parent', function() {
     assert.equal(gp('\\{foo,bar}/'), '{foo,bar}');
     assert.equal(gp('\\{foo,bar\\}/'), '{foo,bar}');
     assert.equal(gp('{foo,bar\\}/'), '.');
-    if (!isWin32) {
+
+    if (isWin32) {
+      // On Windows we are trying to flip backslashes foo-\\( → foo-/(
+      assert.equal(gp('foo-\\(bar\\).md'), 'foo-');
+    } else {
+      assert.equal(gp('foo-\\(bar\\).md'), '.');
       assert.equal(gp('\\[bar]'), '[bar]');
       assert.equal(gp('[bar\\]'), '.');
       assert.equal(gp('\\{foo,bar\\}'), '{foo,bar}');
@@ -132,6 +137,12 @@ describe('glob-parent', function() {
     assert.equal(gp('path/foo'), 'path');
     assert.equal(gp('path/foo/'), 'path/foo');
     assert.equal(gp('path/foo/bar.js'), 'path/foo');
+
+    done();
+  });
+
+  it('should respect disabled auto flip backslashes', function(done) {
+    assert.equal(gp('foo-\\(bar\\).md', { flipBackslashes: false }), '.');
 
     done();
   });


### PR DESCRIPTION
This is a potential fix for #24.