### PR TITLE
Correctly handle the exclamation mark at the beginning of the pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var slash = '/';
 var backslash = /\\/g;
 var enclosure = /[\{\[].*[\/]*.*[\}\]]$/;
 var globby = /(^|[^\\])([\{\[]|\([^\)]+$)/;
-var escaped = /\\([\*\?\|\[\]\(\)\{\}])/g;
+var escaped = /\\([\!\*\?\|\[\]\(\)\{\}])/g;
 
 /**
  * @param {string} str

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -78,6 +78,7 @@ describe('glob-parent', function() {
     assert.equal(gp('[bar]/'), '.');
     assert.equal(gp('./\\[bar]'), './[bar]');
     assert.equal(gp('\\[bar]/'), '[bar]');
+    assert.equal(gp('\\!dir/*'), '!dir');
     assert.equal(gp('[bar\\]/'), '.');
     assert.equal(gp('path/foo \\[bar]/'), 'path/foo [bar]');
     assert.equal(gp('path/\\{foo,bar}/'), 'path/{foo,bar}');


### PR DESCRIPTION
#### What is the purpose of this pull request?

This is a fix for https://github.com/mrmlnc/fast-glob/issues/261.

#### What changes did you make? (Give an overview)

If the pattern has an exclamation mark with escaping at the beginning of the pattern, the base directory is proposed incorrectly.

```js
// Before
\\!dir/* → \\!dir

// After
\\!dir/* → !dir
```