### PR TITLE
chore: add JSDoc @returns information

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var escaped = /\\([\!\*\?\|\[\]\(\)\{\}])/g;
  * @param {string} str
  * @param {Object} opts
  * @param {boolean} [opts.flipBackslashes=true]
+ * @returns {string}
  */
 module.exports = function globParent(str, opts) {
   var options = Object.assign({ flipBackslashes: true }, opts);


### PR DESCRIPTION
Apologies in advance if these kinds of micro-PRs are unwelcome. Otherwise, I think it makes sense to include the `@returns` attribute along with the `@params` attributes in the JSDoc comment.