### PR TITLE
fix!: Correct mishandled escaped path separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var isWin32 = require('os').platform() === 'win32';
 
 var slash = '/';
 var backslash = /\\/g;
-var enclosure = /[{[].*[}\]]$/;
+var enclosure = /[{[].*\/.*[}\]]$/;
 var globby = /(^|[^\\])([{[]|\([^)]+$)/;
 var escaped = /\\([!*?|[\](){}])/g;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,10 +77,10 @@ describe('glob-parent', function () {
       'path/[foo bar]/subdir'
     );
     expect(gp('path/\\[bar]/')).toEqual('path/[bar]');
-    expect(gp('path/\\[bar]')).toEqual('path/[bar]');
+    expect(gp('path/\\[bar]')).toEqual('path');
     expect(gp('[bar]')).toEqual('.');
     expect(gp('[bar]/')).toEqual('.');
-    expect(gp('./\\[bar]')).toEqual('./[bar]');
+    expect(gp('./\\[bar]')).toEqual('.');
     expect(gp('\\[bar]/')).toEqual('[bar]');
     expect(gp('\\!dir/*')).toEqual('!dir');
     expect(gp('[bar\\]/')).toEqual('.');
@@ -95,9 +95,9 @@ describe('glob-parent', function () {
       expect(gp('foo-\\(bar\\).md')).toEqual('foo-');
     } else {
       expect(gp('foo-\\(bar\\).md')).toEqual('.');
-      expect(gp('\\[bar]')).toEqual('[bar]');
+      expect(gp('\\[bar]')).toEqual('.');
       expect(gp('[bar\\]')).toEqual('.');
-      expect(gp('\\{foo,bar\\}')).toEqual('{foo,bar}');
+      expect(gp('\\{foo,bar\\}')).toEqual('.');
       expect(gp('{foo,bar\\}')).toEqual('.');
     }
 


### PR DESCRIPTION
This change fixes the regular expression denial of service
vulnerability.

Refs: https://app.snyk.io/vuln/SNYK-JS-GLOBPARENT-1016905