### PR TITLE
chore(ci): upgrade actions/setup-node to 2

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Node.js version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
## Changes:

- Update `actions/setup-node` to the latest stable version (v2)

## Context:

The tag `v2` points to the `v2.1.5` release right now. `v2.1.4` is the first stable release in the `v2` line.

Read the changelog for the v2.0.0 release to see the major changes, and check out the rest of the changelogs for the `v2` release line as well.

https://github.com/actions/setup-node/releases