### PR TITLE
fix: performance improvement

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var isWin32 = require('os').platform() === 'win32';
 
 var slash = '/';
 var backslash = /\\/g;
-var globby = /(^|[^\\])([{[]|\([^)]+$)/;
 var escaped = /\\([!*?|[\](){}])/g;
 
 /**
@@ -33,7 +32,7 @@ module.exports = function globParent(str, opts) {
   // remove path parts that are globby
   do {
     str = pathPosixDirname(str);
-  } while (isGlob(str) || globby.test(str));
+  } while (isGlobby(str));
 
   // remove escape chars and return result
   return str.replace(escaped, '$1');
@@ -60,4 +59,17 @@ function isEnclosure(str) {
   }
 
   return str.slice(foundIndex + 1, -1).includes(slash);
+}
+
+function isGlobby(str) {
+  if (/\([^()]+$/.test(str))  {
+    return true;
+  }
+  if (str[0] === '{' || str[0] === '[') {
+    return true;
+  }
+  if (/[^\\][{[]/.test(str)) {
+    return true;
+  }
+  return isGlob(str);
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "pretest": "npm run lint",
     "test": "nyc mocha --async-only"
   },
+  "dependencies": {
+    "is-glob": "^4.0.3"
+  },
   "devDependencies": {
     "eslint": "^7.0.0",
     "eslint-config-gulp": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "pretest": "npm run lint",
     "test": "nyc mocha --async-only"
   },
-  "dependencies": {
-    "is-glob": "^4.0.1"
-  },
   "devDependencies": {
     "eslint": "^7.0.0",
     "eslint-config-gulp": "^5.0.0",
@@ -50,5 +47,8 @@
     "directory",
     "base",
     "wildcard"
-  ]
+  ],
+  "dependencies": {
+    "is-glob": "^4.0.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,5 @@
     "directory",
     "base",
     "wildcard"
-  ],
-  "dependencies": {
-    "is-glob": "^4.0.3"
-  }
+  ]
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -242,6 +242,12 @@ describe('glob2base test patterns', function () {
     gp('('.repeat(500000));
     done();
   });
+
+  it("should finish in reasonable time for '/('.repeat(n) + ')'", function (done) {
+    this.timeout(1000);
+    gp('/('.repeat(500000) + ')');
+    done();
+  });
 });
 
 if (isWin32) {


### PR DESCRIPTION
The performance measuring here is confounded a bit by an `is-glob` performance gotcha that is fixed in https://github.com/micromatch/is-glob/pull/15. Here's what I'm seeing running `time node -e "require('./')('/('.repeat(500000) + ')')"` on my 2013 Macbook:

* main branch with is-glob 4.0.2: No idea. I sent SIGINT after **12 minutes** so more than that, and probably a lot more than that.
* this PR with is-glob 4.0.2:  **6.52 seconds**
* this PR with aforementioned is-glob PR: **80 milliseconds**

(The added test will likely fail without the is-glob PR, depending on how performant the test machine is.)