### PR TITLE
fix: support windows path with drive or unc volume

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var isGlob = require('is-glob');
-var pathPosixDirname = require('path').posix.dirname;
+var path = require('path');
+var pathPosixDirname = path.posix.dirname;
 var isWin32 = require('os').platform() === 'win32';
 
 var slash = '/';
@@ -16,6 +17,12 @@ var escaped = /\\([!*?|[\](){}])/g;
 module.exports = function globParent(str, opts) {
   var options = Object.assign({ flipBackslashes: true }, opts);
 
+  var winDriveOrUncVolume = '';
+  if (isWin32) {
+    winDriveOrUncVolume = getWinDriveOrUncVolume(str);
+    str = str.slice(winDriveOrUncVolume.length);
+  }
+
   // flip windows path separators
   if (options.flipBackslashes && isWin32 && str.indexOf(slash) < 0) {
     str = str.replace(backslash, slash);
@@ -28,14 +35,23 @@ module.exports = function globParent(str, opts) {
 
   // preserves full path in case of trailing path separator
   str += 'a';
-
+ 
   // remove path parts that are globby
   do {
     str = pathPosixDirname(str);
   } while (isGlobby(str));
 
   // remove escape chars and return result
-  return str.replace(escaped, '$1');
+  str = str.replace(escaped, '$1');
+
+  // replace continuous slashes to single slash
+  str = str.replace(/\/+/g, '/');
+
+  if (isWin32 && winDriveOrUncVolume) {
+    str = winDriveOrUncVolume + str;
+  }
+
+  return str;
 };
 
 function isEnclosure(str) {
@@ -72,4 +88,15 @@ function isGlobby(str) {
     return true;
   }
   return isGlob(str);
+}
+
+function getWinDriveOrUncVolume(fp) {
+  if (/^([a-zA-Z]:|\\\\)/.test(fp)) {
+    var root = path.win32.parse(fp).root;
+    if (path.win32.isAbsolute(fp)) {
+      root = root.slice(0, -1);  // Strip last path separator
+    }
+    return root;
+  }
+  return '';
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,10 @@ describe('glob-parent', function () {
     expect(gp('.*')).toEqual('.');
     expect(gp('/.*')).toEqual('/');
     expect(gp('/.*/')).toEqual('/');
+    expect(gp('//')).toEqual('/');
+    expect(gp('//*')).toEqual('/');
+    expect(gp('.//')).toEqual('./');
+    expect(gp('.//*')).toEqual('./');
     expect(gp('a/.*/b')).toEqual('a');
     expect(gp('a*/.*/b')).toEqual('.');
     expect(gp('*/a/b/c')).toEqual('.');
@@ -254,6 +258,73 @@ if (isWin32) {
   describe('technically invalid windows globs', function () {
     it('should manage simple globs with backslash path separator', function (done) {
       expect(gp('C:\\path\\*.js')).toEqual('C:/path');
+
+      done();
+    });
+  });
+
+  describe('windows path with drive or UNC volume', function() {
+    it('should return parent dirname from absolute path with drive letter', function(done) {
+      expect(gp('C:/')).toEqual('C:/');
+      expect(gp('C:/.')).toEqual('C:/');
+      expect(gp('C:/*')).toEqual('C:/');
+      expect(gp('C:/./*')).toEqual('C:/.');
+      expect(gp('C://')).toEqual('C:/');
+      expect(gp('C://*')).toEqual('C:/');
+      expect(gp('C:/path/*.js')).toEqual('C:/path');
+
+      expect(gp('C:\\')).toEqual('C:/');
+      expect(gp('C:\\.')).toEqual('C:/');
+      expect(gp('C:\\*')).toEqual('C:/');
+      expect(gp('C:\\.\\*')).toEqual('C:/.');
+      expect(gp('C:\\\\')).toEqual('C:/');
+      expect(gp('C:\\\\*')).toEqual('C:/');
+      expect(gp('C:\\path\\*.js')).toEqual('C:/path');
+
+      done();
+    });
+
+    it('should return parent dirname from relative path with drive letter', function(done) {
+      expect(gp('C:')).toEqual('C:.');
+      expect(gp('C:.')).toEqual('C:.');
+      expect(gp('C:*')).toEqual('C:.');
+      expect(gp('C:./*')).toEqual('C:.');
+      expect(gp('C:.//')).toEqual('C:./');
+      expect(gp('C:.//*')).toEqual('C:./');
+      expect(gp('C:path/*.js')).toEqual('C:path');
+
+      expect(gp('C:.\\*')).toEqual('C:.');
+      expect(gp('C:.\\\\')).toEqual('C:./');
+      expect(gp('C:.\\\\*')).toEqual('C:./');
+      expect(gp('C:path\\*.js')).toEqual('C:path');
+
+      done();
+    });
+
+    it('should return parent dirname from UNC path', function(done) {
+      expect(gp('\\\\System07\\C$/')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/.')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/./*')).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$//')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$//*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/path/*.js')).toEqual('\\\\System07\\C$/path');
+
+      expect(gp('\\\\System07\\C$/', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/.', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/./*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$//', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$//*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/path/*.js')).toEqual('\\\\System07\\C$/path');
+
+      expect(gp('\\\\System07\\C$\\')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\.')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\.\\*')).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$\\\\')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\\\*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\path\\*.js')).toEqual('\\\\System07\\C$/path');
 
       done();
     });


### PR DESCRIPTION
This PR is to fix the issue #63 by separating a drive or a UNC volume from a path string before extracting and combines it after extracting.
And this PR adds replacement of continuous slashes to single slash in a path string.

Closes #63 