### PR TITLE
fix!: remove last '.' and `./'

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/index.js
+++ b/index.js
@@ -47,7 +47,19 @@ module.exports = function globParent(str, opts) {
   // replace continuous slashes to single slash
   str = str.replace(/\/+/g, '/');
 
+  // remove last single dot
+  if (str.slice(-2) === '/.') {
+    str = str.slice(0, -1)
+  }
+  // remove last './'
+  while (str.slice(-3) === '/./') {
+    str = str.slice(0, -2)
+  }
+
   if (isWin32 && winDriveOrUncVolume) {
+    if (str === '.' || str === './') {
+      str = '';
+    }
     str = winDriveOrUncVolume + str;
   }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var isGlob = require('is-glob');
-var pathPosixDirname = require('path').posix.dirname;
+var path = require('path');
+var pathPosixDirname = path.posix.dirname;
 var isWin32 = require('os').platform() === 'win32';
 
 var slash = '/';
@@ -16,6 +17,12 @@ var escaped = /\\([!*?|[\](){}])/g;
 module.exports = function globParent(str, opts) {
   var options = Object.assign({ flipBackslashes: true }, opts);
 
+  var winDriveOrUncVolume = '';
+  if (isWin32) {
+    winDriveOrUncVolume = getWinDriveOrUncVolume(str);
+    str = str.slice(winDriveOrUncVolume.length);
+  }
+
   // flip windows path separators
   if (options.flipBackslashes && isWin32 && str.indexOf(slash) < 0) {
     str = str.replace(backslash, slash);
@@ -28,14 +35,23 @@ module.exports = function globParent(str, opts) {
 
   // preserves full path in case of trailing path separator
   str += 'a';
-
+ 
   // remove path parts that are globby
   do {
     str = pathPosixDirname(str);
   } while (isGlobby(str));
 
   // remove escape chars and return result
-  return str.replace(escaped, '$1');
+  str = str.replace(escaped, '$1');
+
+  // replace continuous slashes to single slash
+  str = str.replace(/\/+/g, '/');
+
+  if (isWin32 && winDriveOrUncVolume) {
+    str = winDriveOrUncVolume + str;
+  }
+
+  return str;
 };
 
 function isEnclosure(str) {
@@ -72,4 +88,15 @@ function isGlobby(str) {
     return true;
   }
   return isGlob(str);
+}
+
+function getWinDriveOrUncVolume(fp) {
+  if (/^([a-zA-Z]:|\\\\)/.test(fp)) {
+    var root = path.win32.parse(fp).root;
+    if (path.win32.isAbsolute(fp)) {
+      root = root.slice(0, -1);  // Strip last path separator
+    }
+    return root;
+  }
+  return '';
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,10 @@ describe('glob-parent', function () {
     expect(gp('.*')).toEqual('.');
     expect(gp('/.*')).toEqual('/');
     expect(gp('/.*/')).toEqual('/');
+    expect(gp('//')).toEqual('/');
+    expect(gp('//*')).toEqual('/');
+    expect(gp('.//')).toEqual('./');
+    expect(gp('.//*')).toEqual('./');
     expect(gp('a/.*/b')).toEqual('a');
     expect(gp('a*/.*/b')).toEqual('.');
     expect(gp('*/a/b/c')).toEqual('.');
@@ -254,6 +258,73 @@ if (isWin32) {
   describe('technically invalid windows globs', function () {
     it('should manage simple globs with backslash path separator', function (done) {
       expect(gp('C:\\path\\*.js')).toEqual('C:/path');
+
+      done();
+    });
+  });
+
+  describe('windows path with drive or UNC volume', function() {
+    it('should return parent dirname from absolute path with drive letter', function(done) {
+      expect(gp('C:/')).toEqual('C:/');
+      expect(gp('C:/.')).toEqual('C:/');
+      expect(gp('C:/*')).toEqual('C:/');
+      expect(gp('C:/./*')).toEqual('C:/.');
+      expect(gp('C://')).toEqual('C:/');
+      expect(gp('C://*')).toEqual('C:/');
+      expect(gp('C:/path/*.js')).toEqual('C:/path');
+
+      expect(gp('C:\\')).toEqual('C:/');
+      expect(gp('C:\\.')).toEqual('C:/');
+      expect(gp('C:\\*')).toEqual('C:/');
+      expect(gp('C:\\.\\*')).toEqual('C:/.');
+      expect(gp('C:\\\\')).toEqual('C:/');
+      expect(gp('C:\\\\*')).toEqual('C:/');
+      expect(gp('C:\\path\\*.js')).toEqual('C:/path');
+
+      done();
+    });
+
+    it('should return parent dirname from relative path with drive letter', function(done) {
+      expect(gp('C:')).toEqual('C:.');
+      expect(gp('C:.')).toEqual('C:.');
+      expect(gp('C:*')).toEqual('C:.');
+      expect(gp('C:./*')).toEqual('C:.');
+      expect(gp('C:.//')).toEqual('C:./');
+      expect(gp('C:.//*')).toEqual('C:./');
+      expect(gp('C:path/*.js')).toEqual('C:path');
+
+      expect(gp('C:.\\*')).toEqual('C:.');
+      expect(gp('C:.\\\\')).toEqual('C:./');
+      expect(gp('C:.\\\\*')).toEqual('C:./');
+      expect(gp('C:path\\*.js')).toEqual('C:path');
+
+      done();
+    });
+
+    it('should return parent dirname from UNC path', function(done) {
+      expect(gp('\\\\System07\\C$/')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/.')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/./*')).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$//')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$//*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/path/*.js')).toEqual('\\\\System07\\C$/path');
+
+      expect(gp('\\\\System07\\C$/', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/.', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/./*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$//', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$//*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$/path/*.js')).toEqual('\\\\System07\\C$/path');
+
+      expect(gp('\\\\System07\\C$\\')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\.')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\.\\*')).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$\\\\')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\\\*')).toEqual('\\\\System07\\C$/');
+      expect(gp('\\\\System07\\C$\\path\\*.js')).toEqual('\\\\System07\\C$/path');
 
       done();
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -252,6 +252,41 @@ describe('glob2base test patterns', function () {
     gp('/('.repeat(500000) + ')');
     done();
   });
+
+  it('should remove tail \'.\' and \'./\'', function(done) {
+    expect(gp('foo/./*')).toEqual('foo/');
+    expect(gp('foo/./././*')).toEqual('foo/');
+    expect(gp('./././*')).toEqual('./');
+    expect(gp('/./././*')).toEqual('/');
+
+    if (isWin32) {
+      expect(gp('C:/foo/./*')).toEqual('C:/foo/');
+      expect(gp('C:/foo/./././*')).toEqual('C:/foo/');
+      expect(gp('C:/./././*')).toEqual('C:/');
+
+      expect(gp('C:\\foo\\.\\*')).toEqual('C:/foo/');
+      expect(gp('C:\\foo\\.\\.\\.\\*')).toEqual('C:/foo/');
+      expect(gp('C:\\.\\.\\.\\*')).toEqual('C:/');
+
+      expect(gp('C:foo/./*')).toEqual('C:foo/');
+      expect(gp('C:foo/./././*')).toEqual('C:foo/');
+      expect(gp('C:./././*')).toEqual('C:');
+
+      expect(gp('C:foo\\.\\*')).toEqual('C:foo/');
+      expect(gp('C:foo\\.\\.\\.\\*')).toEqual('C:foo/');
+      expect(gp('C:.\\.\\.\\*')).toEqual('C:');
+
+      expect(gp('\\\\System07\\C$/foo/./*')).toEqual('\\\\System07\\C$/foo/');
+      expect(gp('\\\\System07\\C$/foo/./././*')).toEqual('\\\\System07\\C$/foo/');
+      expect(gp('\\\\System07\\C$/./././*')).toEqual('\\\\System07\\C$/');
+
+      expect(gp('\\\\System07\\C$\\foo\\.\\*')).toEqual('\\\\System07\\C$/foo/');
+      expect(gp('\\\\System07\\C$\\foo\\.\\.\\.\\*')).toEqual('\\\\System07\\C$/foo/');
+      expect(gp('\\\\System07\\C$\\.\\.\\.\\*')).toEqual('\\\\System07\\C$/');
+    }
+
+    done();
+  });
 });
 
 if (isWin32) {
@@ -268,7 +303,7 @@ if (isWin32) {
       expect(gp('C:/')).toEqual('C:/');
       expect(gp('C:/.')).toEqual('C:/');
       expect(gp('C:/*')).toEqual('C:/');
-      expect(gp('C:/./*')).toEqual('C:/.');
+      expect(gp('C:/./*')).toEqual('C:/');
       expect(gp('C://')).toEqual('C:/');
       expect(gp('C://*')).toEqual('C:/');
       expect(gp('C:/path/*.js')).toEqual('C:/path');
@@ -276,7 +311,7 @@ if (isWin32) {
       expect(gp('C:\\')).toEqual('C:/');
       expect(gp('C:\\.')).toEqual('C:/');
       expect(gp('C:\\*')).toEqual('C:/');
-      expect(gp('C:\\.\\*')).toEqual('C:/.');
+      expect(gp('C:\\.\\*')).toEqual('C:/');
       expect(gp('C:\\\\')).toEqual('C:/');
       expect(gp('C:\\\\*')).toEqual('C:/');
       expect(gp('C:\\path\\*.js')).toEqual('C:/path');
@@ -285,17 +320,17 @@ if (isWin32) {
     });
 
     it('should return parent dirname from relative path with drive letter', function(done) {
-      expect(gp('C:')).toEqual('C:.');
-      expect(gp('C:.')).toEqual('C:.');
-      expect(gp('C:*')).toEqual('C:.');
-      expect(gp('C:./*')).toEqual('C:.');
-      expect(gp('C:.//')).toEqual('C:./');
-      expect(gp('C:.//*')).toEqual('C:./');
+      expect(gp('C:')).toEqual('C:');
+      expect(gp('C:.')).toEqual('C:');
+      expect(gp('C:*')).toEqual('C:');
+      expect(gp('C:./*')).toEqual('C:');
+      expect(gp('C:.//')).toEqual('C:');
+      expect(gp('C:.//*')).toEqual('C:');
       expect(gp('C:path/*.js')).toEqual('C:path');
 
-      expect(gp('C:.\\*')).toEqual('C:.');
-      expect(gp('C:.\\\\')).toEqual('C:./');
-      expect(gp('C:.\\\\*')).toEqual('C:./');
+      expect(gp('C:.\\*')).toEqual('C:');
+      expect(gp('C:.\\\\')).toEqual('C:');
+      expect(gp('C:.\\\\*')).toEqual('C:');
       expect(gp('C:path\\*.js')).toEqual('C:path');
 
       done();
@@ -305,7 +340,7 @@ if (isWin32) {
       expect(gp('\\\\System07\\C$/')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$/.')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$/*')).toEqual('\\\\System07\\C$/');
-      expect(gp('\\\\System07\\C$/./*')).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$/./*')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$//')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$//*')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$/path/*.js')).toEqual('\\\\System07\\C$/path');
@@ -313,7 +348,7 @@ if (isWin32) {
       expect(gp('\\\\System07\\C$/', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$/.', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$/*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
-      expect(gp('\\\\System07\\C$/./*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$/./*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$//', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$//*', { flipBackslashes: false })).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$/path/*.js')).toEqual('\\\\System07\\C$/path');
@@ -321,7 +356,7 @@ if (isWin32) {
       expect(gp('\\\\System07\\C$\\')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$\\.')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$\\*')).toEqual('\\\\System07\\C$/');
-      expect(gp('\\\\System07\\C$\\.\\*')).toEqual('\\\\System07\\C$/.');
+      expect(gp('\\\\System07\\C$\\.\\*')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$\\\\')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$\\\\*')).toEqual('\\\\System07\\C$/');
       expect(gp('\\\\System07\\C$\\path\\*.js')).toEqual('\\\\System07\\C$/path');


### PR DESCRIPTION
This PR modifies based on #64.

The current `glob-parent` returns `'/.'` from `'/./*'` in the result path..
I've modified it to return `/'` by removing last '.'

Similarly, I've modified to remove last `'./'` in the result path, too.
