### PR TITLE
Use "node:" prefixed imports everywhere for node imports.

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,15 +30,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14]
+        node: [14.18.0, 14, 16.0.0, 16]
         os: [ubuntu-latest, windows-latest, macos-latest]
-
+        exclude:
+          # Node 14 is not available on macos anymore
+          - os: macos-latest
+            node-version: 14
+          - os: macos-latest
+            node-version: 14.18.0
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
       - name: Set Node.js version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var isGlob = require('is-glob');
-var pathPosixDirname = require('path').posix.dirname;
-var isWin32 = require('os').platform() === 'win32';
+var pathPosixDirname = require('node:path').posix.dirname;
+var isWin32 = require('node:os').platform() === 'win32';
 
 var slash = '/';
 var backslash = /\\/g;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "gulpjs/glob-parent",
   "license": "ISC",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=14.18.0 <15 || >=16"
   },
   "main": "index.js",
   "files": [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@
 
 var gp = require('../');
 var expect = require('expect');
-var isWin32 = require('os').platform() === 'win32';
+var isWin32 = require('node:os').platform() === 'win32';
 
 describe('glob-parent', function () {
   it('should strip glob magic to return parent path', function (done) {


### PR DESCRIPTION
Adjust minimum node version and update CI accordingly.

---

Using "node:" prefixed imports enables the use of this library in runtimes other than node where node compatibility layer is provided for prefixed imports (e.g. `workerd`). The cost is that the minimum nodejs version needs to be bumped to ">=14.18.0 <15 || >=16", where this feature was introduced.